### PR TITLE
Allow the EV3 to hang on exit like other nerves systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,15 @@ manually load the driver via `modprobe asix`.
 
 On most platforms, the default behavior of Nerves is to hang if something goes wrong.
 This is good for debugging since rebooting makes it easy to lose console
-messages or it might hide the issue completely. Hanging on the EV3 forces you
-to remove and reinsert the batteries since there's no reboot button. The default
-behavior has been changed to power down instead.
+messages or it might hide the issue completely. On the EV3 hanging
+requires a slightly more complex restarting process.
+
+  1. Hold down the Back, center, and left buttons on the EV3 Brick .
+  2. When the screen goes blank, release the Back button .
+  3. When the screen says “Starting,” release the center and left buttons
+
+If you would like to power down instead you will need to change `erlinit.config`
+from `--hang-on-exit` to `---poweroff-on-exit`.
 
 If you're attached to the console, you may see a kernel panic when you run power
 off. From what I can tell, this panic happens after the important parts of

--- a/rootfs-additions/etc/erlinit.config
+++ b/rootfs-additions/etc/erlinit.config
@@ -21,7 +21,7 @@
 
 # Uncomment to hang the board rather than rebooting when Erlang exits
 # NOTE: This is for unexpected exits, so you may want to change this to reboot.
---poweroff-on-exit
+--hang-on-exit
 
 # Change the graceful shutdown time. If 10 seconds isn't long enough between
 # calling "poweroff", "reboot", or "halt" and :init.stop/0 stopping all OTP


### PR DESCRIPTION
The EV3 system does not have a well-known reboot button so many people
pull the battery to reboot the EV3. In favor of not losing important
debugging information, it would be nice to not have the brick power off
when it hangs and to consistently behave across nerves systems.

In order to make it simpler, I documented the reboot process of the EV3
in the README. If the user would like to go back to the old behaviour I
also included directions to change the `erlinit.config`

closes #9 

Amos King @adkron <amos@binarynoggin.com>